### PR TITLE
Add support for dedicated bus ways

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
     <script src="https://cdn.jsdelivr.net/npm/leaflet.locatecontrol@0.62.0/src/L.Control.Locate.min.js"></script>
     <script src="https://cdn.rawgit.com/tyrasd/jxon/master/jxon.min.js"></script>
     <script src="https://cdn.rawgit.com/osmlab/osm-auth/master/osmauth.min.js"></script>
-    
+
     <style>
         #map  { width: 100%; height: 100%; position: absolute; left: 0; top: 0; }
         .legend-element { display:inline-block; width:30px; height:3px; vertical-align:middle; overflow:hidden; }
@@ -27,6 +27,7 @@
         .float-right { float: right; }
         #right { background-color: #fee2fe; }
         #left { background-color:  lightcyan; }
+        #middle { background-color:  lightgreen; }
         ::placeholder { color: gainsboro; }
         img.sign { margin: 2px; }
         symb-icon { font-size: 140%; }

--- a/planes.js
+++ b/planes.js
@@ -531,7 +531,7 @@ function getQueryBusLanes() {
         var bbox = [bounds.getSouth(), bounds.getWest(), bounds.getNorth(), bounds.getEast()].join(',');
         return editorMode
             ? '[out:xml];(way[highway~"^motorway|trunk|primary|secondary|tertiary|unclassified|residential"](' + bbox + ');)->.a;(.a;.a >;.a <;);out meta;'
-            : '[out:xml];(way["highway"][~"^(lanes:(psv|bus)|busway).*"~"."](' + bbox + ');way["highway"][~"psv|bus"~"yes"](' + bbox + ');)->.a;(.a;.a >;);out meta;';
+            : '[out:xml];(way["highway"][~"^(lanes:(psv|bus)|busway).*"~"."](' + bbox + ');way["highway"][access=no][~"psv|bus"~"yes"](' + bbox + ');)->.a;(.a;.a >;);out meta;';
     }
 }
 

--- a/taginfo.json
+++ b/taginfo.json
@@ -15,6 +15,7 @@
         { "key": "highway", "value": "tertiary", "object_types": [ "way" ], "description": "major road" },
         { "key": "highway", "value": "unclassified", "object_types": [ "way" ], "description": "major road" },
         { "key": "highway", "value": "residential", "object_types": [ "way" ], "description": "major road" },
+        { "key": "highway", "value": "service", "object_types": [ "way" ], "description": "candidate for bus/psv dedicated road" },
 
         { "key": "lanes:bus",  "object_types": [ "way" ] },
         { "key": "lanes:bus", "value": "2", "object_types": [ "way" ] },
@@ -46,6 +47,9 @@
         { "key": "lanes:psv", "value": "8", "object_types": [ "way" ] },
         { "key": "lanes:psv", "value": "9", "object_types": [ "way" ] },
         { "key": "lanes:psv:forward",  "object_types": [ "way" ] },
-        { "key": "lanes:psv:backward",  "object_types": [ "way" ] }
+        { "key": "lanes:psv:backward",  "object_types": [ "way" ] },
+
+        { "key": "bus", "value": "yes", "object_types": [ "way" ] },
+        { "key": "psv", "value": "yes", "object_types": [ "way" ] }
     ]
 }


### PR DESCRIPTION
about #2

I've updated the overpass query to also get dedicated bus highways and display them.
![image](https://user-images.githubusercontent.com/919962/68997912-fe791780-08ab-11ea-9b81-9118f51c412e.png)

I think some refactoring is needed for the display, because the right / left distinction is not really relevant for these kind of ways.
And I did not look at the editorMode yet.

